### PR TITLE
Utiliser une expression régulière plutôt qu'une correspondance exacte pour le préfixe des noms d'applications

### DIFF
--- a/scalingo.sp
+++ b/scalingo.sp
@@ -35,11 +35,11 @@ control "scalingo_app_name_prefix" {
     select
       name as resource,
       case
-        when starts_with(name, $1) then 'ok'
+        when name SIMILAR TO $1 || '%' then 'ok'
         else 'alarm'
       end as status,
       case
-        when starts_with(name, $1) then 'L''application ' || name || ' commence par ' || $1 || '.'
+        when name SIMILAR TO $1 || '%' then 'L''application ' || name || ' commence par ' || $1 || '.'
         else  'L''application ' || name || ' ne commence pas par ' || $1 || '.'
       end as reason
     from


### PR DESCRIPTION
Pour le tester : 

Au lieu de la valeur par défaut pour `app_name_prefix`, utiliser une valeur similaire à celle de `app_name_suffix`. 