### PR TITLE
Vérifier que l'application n'est pas lié à un repository

### DIFF
--- a/scalingo.sp
+++ b/scalingo.sp
@@ -194,9 +194,9 @@ control "scalingo_no_linked_repository_on_production" {
         else  'L''application ' || app.name || ' est liée au repository '|| srl.scm_type || ':' || srl.owner || '/'|| srl.repo || '.'
       end as reason
     from
-      scalingo_all.scalingo_scm_repo_link srl
+      scalingo_scm_repo_link srl
     left join
-      scalingo_all.scalingo_app app on app.id = srl.app_id
+      scalingo_app app on app.id = srl.app_id
   EOT
 
   param "exclusion" {


### PR DESCRIPTION
## :christmas_tree: Problème
Pour https://github.com/1024pix/steampipe-checks/pull/24/

## :gift: Proposition
Vérifier que `scalingo_scm_repo_link.owner` n'est pas renseigné.

## :star2: Remarques
Les applications de tests `pix-test-steampipe-repo-*-production` n'apparaissent pas dans la table `scalingo_scm_repo_link`.
Elles ont pourtant été créés via Slack. Demande en cours chez Scalingo.

## :santa: Pour tester

### Applications existantes

Exécuter les checks en local
```shell
steampipe check benchmark.scalingo
```
Vous obtenez
```shell
 Aucun repository n'est lié à une application de production. ........................................................... CRITICAL 10 /   189 [==        ]
| | 
| ALARM: L'application xxxxxx est liée au repository github:1024pix/xxxxxxx.
[....]
| SKIP : L'application xxxxxxx n'est pas de la production. 
```

Vérifier que les applications en `ALARM` sont liées à un repository dans Scalingo


### Applications de test

Exécuter les checks en local
```shell
steampipe check benchmark.scalingo | grep -A 50 lié | grep pix-test-steampipe-repo
```

Vérifier que 
- l'application  `pix-test-steampipe-repo-ok-production` est OK
- l'application `pix-test-steampipe-repo-ko-production` est KO


