### PR TITLE
[BUGFIX] Corrige les requêtes pour la nouvelle version du plugin scalingo

### DIFF
--- a/scalingo.sp
+++ b/scalingo.sp
@@ -170,7 +170,7 @@ control "scalingo_no_auto_deploy_on_production" {
     from
       scalingo_scm_repo_link srl
     join
-      scalingo_app app on app.id = srl.app_id
+      scalingo_app app on app.name = srl.app_name
   EOT
 
   param "exclusion" {
@@ -267,7 +267,7 @@ control "scalingo_no_deploy_review_apps" {
     from
       scalingo_scm_repo_link srl
     join
-      scalingo_app app on app.id = srl.app_id
+      scalingo_app app on app.name = srl.app_name
   EOT
 
   param "exclusion" {


### PR DESCRIPTION
## :christmas_tree: Problème
La nouvelle version du plugin scalingo introduit des changements cassant.

## :gift: Proposition
Réparer.

## :santa: Pour tester
Il faut attendre la version du plugin et/ou compiler la branch main du plugin.
