### PR TITLE
:wrench: Disable tcp log drains check

### DIFF
--- a/mod.sp
+++ b/mod.sp
@@ -4,7 +4,7 @@ mod "pix_scalingo" {
 
   require {
     plugin "francois2metz/scalingo" {
-      version = "0.0.8"
+      version = "0.15.0"
     }
   }
 }

--- a/scalingo.sp
+++ b/scalingo.sp
@@ -327,7 +327,8 @@ control "scalingo_log_drain_on_production_addon" {
     left join
       scalingo_log_drain_addon sld on addon.id = sld.id and sld.app_name = addon.app_name
     where
-      app.name LIKE '%-production'
+      app.name LIKE '%-production' and
+      addon.provider_id != 'tcp-gateway'
   EOT
 
   param "exclusion" {


### PR DESCRIPTION
## :christmas_tree: Problème
Le check de log drain passe également sur les addons TCP, alors que ceux ci n'exportent pas de logs

## :gift: Proposition
Désactiver complètement le check de log drain sur ces addons

## :star2: Remarques
En essayant d'ajouter le log drain sur un addon tcp : 
```
scalingo --app xxxx --region xxxx log-drains-add --type datadog --token xxx --drain-region eu --with-addons
Warning: At the moment, only database addons are able to forward logs to a drain.
-----> fail to add drain to 'pix-steampipe-dashboard-production' application:
	 fail to add drain: 400 Bad Request → drain already exists
-----> fail to add drain to 'TCP Gateway' addon:
	 fail to add log drain to the addon xxxxxxxxxx: 400 Bad Request → This addon doesn't support log drains
```

## :santa: Pour tester
Lancer les checks et vérifier que les logs drains de cet addon ne sont pas vérifiés
