### PR TITLE
[TECH] Exclure les reviews app du checks de review apps activées

### DIFF
--- a/scalingo.sp
+++ b/scalingo.sp
@@ -279,6 +279,8 @@ control "scalingo_no_deploy_review_apps" {
         ) as deploy_review_apps_enabled
       from
         scalingo_app app
+      where
+        name NOT LIKE '%review-pr%'
     )
     select
       name as resource,


### PR DESCRIPTION
## :unicorn: Problème
Le check des review app active vérifie également l'état d'activation sur les RA, alors qu'elles ne peuvent pas être activées sur des RA

## :robot: Proposition
Désactiver le check de l'activation des RA sur les RA dont le nom suit le schéma de nommage classique des RA `*-review-pr*`.

## :rainbow: Remarques

```
> .timing on
> .cache clear
> EXPLAIN ANALYZE select
        name,
        owner_username,
        (
          select
            deploy_review_apps_enabled
          from
            scalingo_scm_repo_link
          where
            app_name = name
        ) as deploy_review_apps_enabled
      from
        scalingo_app app
+-------------------------------------------------------------------------------------------------------------------------------------------------------+
| QUERY PLAN                                                                                                                                            |
+-------------------------------------------------------------------------------------------------------------------------------------------------------+
| Foreign Scan on scalingo_app app  (cost=0.00..20000020000000000000.00 rows=1000000 width=65) (actual time=399.755..53574.119 rows=238 loops=1)        |
|   SubPlan 1                                                                                                                                           |
|     ->  Foreign Scan on scalingo_scm_repo_link  (cost=0.00..20000000000000.00 rows=1000000 width=200) (actual time=203.825..223.481 rows=1 loops=238) |
|           Filter: (app_name = app.name)                                                                                                               |
| Planning Time: 2.590 ms                                                                                                                               |
| Execution Time: 53575.627 ms                                                                                                                          |
+-------------------------------------------------------------------------------------------------------------------------------------------------------+
```
Time: 53.6s. Rows fetched: 438. Hydrate calls: 0.


```
> .timing on
> .cache clear
> EXPLAIN ANALYZE select
        name,
        owner_username,
        (
          select
            deploy_review_apps_enabled
          from
            scalingo_scm_repo_link
          where
            app_name = name
        ) as deploy_review_apps_enabled
      from
        scalingo_app app
        where
          name NOT LIKE '%review-pr%'
+------------------------------------------------------------------------------------------------------------------------------------------------------+
| QUERY PLAN                                                                                                                                           |
+------------------------------------------------------------------------------------------------------------------------------------------------------+
| Foreign Scan on scalingo_app app  (cost=0.00..20000020000000000000.00 rows=1000000 width=65) (actual time=469.865..19012.613 rows=90 loops=1)        |
|   Filter: (name !~~ '%review-pr%'::text)                                                                                                             |
|   Rows Removed by Filter: 148                                                                                                                        |
|   SubPlan 1                                                                                                                                          |
|     ->  Foreign Scan on scalingo_scm_repo_link  (cost=0.00..20000000000000.00 rows=1000000 width=200) (actual time=199.271..208.206 rows=1 loops=90) |
|           Filter: (app_name = app.name)                                                                                                              |
| Planning Time: 3.219 ms                                                                                                                              |
| Execution Time: 19015.080 ms                                                                                                                         |
+------------------------------------------------------------------------------------------------------------------------------------------------------+
```
Time: 19.0s. Rows fetched: 291. Hydrate calls: 0.



## :100: Pour tester
Lancer le check et vérifier que les résultats sont cohérents avec les anciens
