### PR TITLE
[TECH] Utilise le paramètre min_version plutot version sur le mod

### DIFF
--- a/mod.sp
+++ b/mod.sp
@@ -4,7 +4,7 @@ mod "pix_scalingo" {
 
   require {
     plugin "francois2metz/scalingo" {
-      version = "0.15.0"
+      min_version = "0.15.0"
     }
   }
 }


### PR DESCRIPTION
## :unicorn: Problème
La configuration `version` est déprécié. `min_version` est la façon recommandée désormais.

## :robot: Proposition
Utiliser `min_version`.

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
Lancer le control et voir qu'il n'y a pas de message de dépréciation.
